### PR TITLE
Remove `::` from empty tag example

### DIFF
--- a/lib/algae.ex
+++ b/lib/algae.ex
@@ -132,22 +132,22 @@ defmodule Algae do
 
   The `new` constructor function may be overwritten.
 
-      defmodule Constant do
-        defdata :: fun()
-
-        def new(value), do: %Constant{constant: fn _ -> value end}
-      end
-
-      fourty_two = Constant.new(42)
-      fourty_two.constant.(33)
-      #=> 42
+      iex> defmodule Constant do
+      ...>   defdata fun()
+      ...>
+      ...>   def new(value), do: %Constant{constant: fn _ -> value end}
+      ...> end
+      ...>
+      ...> fourty_two = Constant.new(42)
+      ...> fourty_two.constant.(33)
+      42
 
   ## Empty Tag
 
   An empty type (with no fields) is definable using the `none`() type
 
       defmodule Nothing do
-        defdata :: none()
+        defdata none()
       end
 
       Nothing.new()

--- a/test/algae_test.exs
+++ b/test/algae_test.exs
@@ -2,6 +2,7 @@ defmodule AlgaeTest do
   alias Example.{Wrapper, Media, Book, Animal}
   use ExUnit.Case
 
+  doctest Algae, import: true
   doctest Algae.Id, import: true
 
   doctest Algae.Maybe,  import: true


### PR DESCRIPTION
Typo in docs showing `::` in an example that uses an empty tag. I wish the syntax were more consistent, but the parser continues to give me trouble. Also wish that I could doc test this entire file, but getting compile errors on all other examples 😭 Perhaps will put some time in and see if there's some way to improve this these days (been a few years since I checked)

Fixes #32 