### PR TITLE
Resolve aliases

### DIFF
--- a/lib/algae.ex
+++ b/lib/algae.ex
@@ -185,10 +185,10 @@ defmodule Algae do
         data_ast(caller_module, type)
 
       [do: {:__block__, _, lines}] ->
-        data_ast(lines)
+        data_ast(lines, __CALLER__)
 
       [do: line] ->
-        data_ast([line])
+        data_ast([line], __CALLER__)
     end
   end
 
@@ -204,7 +204,7 @@ defmodule Algae do
            {:__block__, _, lines} -> lines
            line -> List.wrap(line)
       end
-      |> data_ast()
+      |> data_ast(__CALLER__)
 
     quote do
       defmodule unquote(module_name) do

--- a/test/algae_dsl_aliasing_test.exs
+++ b/test/algae_dsl_aliasing_test.exs
@@ -1,0 +1,23 @@
+defmodule AlgaeDslAliasingTest.Base do
+  import Algae
+
+  alias __MODULE__
+
+  defmodule A do
+    defdata do
+      a :: String.t()
+    end
+  end
+
+  defmodule B do
+    defdata do
+      b :: Base.A.t() \\ Base.A.new("a for amazing!")
+    end
+  end
+
+  defmodule C do
+    defdata do
+      c :: Base.B.t()
+    end
+  end
+end


### PR DESCRIPTION
Fixes #29 

---

This change allows for the resolving/expanding of aliases.

```elixir
defmodule Simple.NonFlowering.Aquatic.Plant do
  import Algae
  alias __MODULE__

  defmodule Seaweeds do
    defdata ..
  end

  defdata do
    # Before
    a :: Simple.NonFlowering.Aquatic.Plant.Seaweeds.t
    # After
    a :: Plant.Seaweeds.t
  end
end
```

--- 

Notes:
- Weirdly `a :: Plant.Seaweeds.t \\ Plant.Seaweeds.new(..)` does work
- Same goes for `a :: list(Plant.Seaweeds.t)`
- Given the previous notes, I wonder if there's an easier fix without using `Macro.expand`?

:v: