### PR TITLE
Add note to README to `import Algae`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ end
   - [`Maybe`](#algaemaybe)
   - [`Tree.BinarySearch`](#algaetreebinarysearch)
 
+---
+
+> **NOTE**  
+> Please `import Algae` before trying out the examples below.
+> The samples assume that is has already been done to remove
+> the unnecessary clutter.
+
+---
+
 # Product Builder
 Build a product type
 


### PR DESCRIPTION
Response to #25 - I think adding an `import` to all examples would add clutter, so probably adding a note at the beginning seems like a good compromise.